### PR TITLE
Populera Lösenåterställningsinformation

### DIFF
--- a/Anvandare.gs
+++ b/Anvandare.gs
@@ -501,4 +501,4 @@ function listAllUsers() {
     }
     pageToken = page.nextPageToken;
   } while (pageToken);
-}Bandbredd
+}

--- a/Anvandare.gs
+++ b/Anvandare.gs
@@ -274,10 +274,10 @@ function checkIfEmailExists(email) {
  */
 function updateAccount(member, useraccount, orgUnitPath) {
   
-//  var phnum = intphonenumber(member.contact_mobile_phone); // gör mobilnummret till internationellt nummer om möjligt
+  var phnum = intphonenumber(member.contact_mobile_phone); // gör mobilnummret till internationellt nummer om möjligt
   var update = false;
   
-  if ( useraccount.name.givenName != member.first_name || useraccount.name.familyName != member.last_name || useraccount.suspended || useraccount.orgUnitPath != orgUnitPath ) { // || ((!useraccount.recoveryEmail) && (member.email)) || ((useraccount.recoveryPhone != phnum) && (member.contact_mobile_phone)) 
+  if ( useraccount.name.givenName != member.first_name || useraccount.name.familyName != member.last_name || useraccount.suspended || useraccount.orgUnitPath != orgUnitPath  || ((!useraccount.recoveryEmail) && (member.email)) || ((useraccount.recoveryPhone != phnum) && (member.contact_mobile_phone)) ){
   // Något behöver uppdateras
     Logger.log('Användare %s %s uppdateras', useraccount.name.givenName, useraccount.name.familyName);  
 
@@ -308,7 +308,7 @@ function updateAccount(member, useraccount, orgUnitPath) {
       user.recoveryEmail = member.email;
       update = true;
     };
-/* Lägg till återställningsinformation på Googlekontot
+    // Lägg till återställningsinformation på Googlekontot
     if((useraccount.recoveryPhone != phnum) && (member.contact_mobile_phone))
     {  
       if(phnum){
@@ -322,7 +322,7 @@ function updateAccount(member, useraccount, orgUnitPath) {
       Logger.log("Aktiverad.");
       user.suspended = false;
     }
-*/
+
     try{
     user = AdminDirectory.Users.update(user, useraccount.primaryEmail);
     //Logger.log("Användaren är nu i org " + orgUnitPath);
@@ -501,4 +501,4 @@ function listAllUsers() {
     }
     pageToken = page.nextPageToken;
   } while (pageToken);
-}
+}Bandbredd

--- a/Gemensamma_funktioner.gs
+++ b/Gemensamma_funktioner.gs
@@ -584,6 +584,51 @@ function removeDublicates(list) {
   return tmp_array;
 }
 
+/**
+ * Gör strängen till ett svenskt internationellt nummer om möjligt
+ */
+
+function intphonenumber(phnum) {
+  var rx = /^\+/;      
+  //Logger.log('telefonnummer före: %s', phnum);  
+  var res = phnum.match(rx)
+  if(res)
+  {
+    var ccok = false;
+    Logger.log('Match');  
+ 
+    var ccodes =[];
+    ccodes.push("43"); //
+    ccodes.push("44"); //
+    ccodes.push("45"); //Danmark
+    ccodes.push("46"); //sverige
+    for(var info in ccodes)
+    {
+      rx = new RegExp('^\\+' + ccodes[info]  , 'g');   
+      if (phnum.match(rx))
+        {
+          phnum = "+" +  ccodes[info] + phnum.substr(3).replace(/[^0-9]/g, '');
+        ccok = true;
+        }
+    }
+    if (!ccok){phnum = null;}
+ //Logger.log('after cc %s',phnum);  
+  
+  }
+  else
+  {
+   // Logger.log('NoMatch');  
+    if (phnum.replace(/[^0-9]/g, '').match(/^0/)){
+        phnum = "+46" + phnum.replace(/[^0-9]/g, '').substr(1)
+      }
+    else {
+//phnum = null
+    }
+  }
+   //Logger.log('done... %s',phnum);  
+  
+return phnum
+}
 
 String.prototype.endsWith = function(suffix) { 
    if (this.length < suffix.length) 

--- a/Konfiguration.gs
+++ b/Konfiguration.gs
@@ -44,14 +44,17 @@ var scoutnet_url = 'www.scoutnet.se'; //Scoutnets webbadress
 var userAccountConfig = [
   {
     scoutnetListId: "1234",  //
-    orgUnitPath: "Styrelsen" //om du skriver Ledare så är det egentligen underorganisationen /Scoutnet/Ledare
+    orgUnitPath: "Styrelsen",  //om du skriver Ledare så är det egentligen underorganisationen /Scoutnet/Ledare
+    description: "gruppen med personer i Styrelsen" // valfritt,  beskrivning för att kunna följa loggen lättare
   },
   {
     scoutnetListId: "8&rule_id=9874 (Roverscouter), 1122 (Kassör)", //Rover
-    orgUnitPath: "Kårfunk/Rover"
+    orgUnitPath: "Kårfunk/Rover",
+    description: "Rover och kassörer"
   },
   {
     scoutnetListId: "8 (Lurk)", //Ledare, Utmanare, Rover, Kårfunktionärer. Då alla roverscouter och kårkassören redan är med i en lista kommer de ej med här
-    orgUnitPath: "Kårfunk/LURK"
+    orgUnitPath: "Kårfunk/LURK",
+    description: "Ledare, Utmanare, Rover, Kårfunktionärer"
   }
 ];


### PR DESCRIPTION
#21 
Lägg till Medlemens Primära epostadress och mobilnummer som återställningsinformation på Googlekontot.
då kan en ny kontoinnehavare enkelt "återställa" sitt lösenord för att få tillgång till sitt nya konto.
Beskrivning för loggen skull,  som option i konfigurationsfilen 