### PR TITLE
Löser problem med att sync:en krashar pga konton utan scoutnetid.

### DIFF
--- a/Anvandare.gs
+++ b/Anvandare.gs
@@ -70,7 +70,7 @@ function Anvandare() {
         var obj = allMembers.find(obj => obj.member_no == membersInAList[i].member_no); //Leta upp kontot i listan övar alla konton 
         //anledningen till att inte använda objektet från epostlistan är att det finns bara begränsad information i det objektet
 
-        var GoUser = useraccounts.find(u => u.externalIds.some(extid => extid.type === "organization" && extid.value === obj.member_no)); // leta upp befintligt Googlekonto som representerar rätt objekt
+        var GoUser = useraccounts.find(u => u.externalIds !== undefined && u.externalIds.some(extid => extid.type === "organization" && extid.value === obj.member_no)); // leta upp befintligt Googlekonto som representerar rätt objekt
         if(GoUser) {
         // Användaren fanns i listan
           const ia = useraccounts.length


### PR DESCRIPTION
Om en användare läggs in (manuellt) i scoutnet-organisationen så krashar syncen på grund av att scoutnet-id inte finns.

Denna fix gör att kontot kommer att flyttas till "avstängda" precis som konton som inte finns i scoutnet.