### PR TITLE
Fix uppdatering efternamn

### DIFF
--- a/Anvandare.gs
+++ b/Anvandare.gs
@@ -433,7 +433,7 @@ function updateAccount(member, useraccount, orgUnitPath, defaultUserAvatar, defa
       if (!user.name)
       {user.name = {}}
       Logger.log("Nytt efternamn: %s", member.last_name);
-      user.name.givenName = member.last_name;
+      user.name.familyName = member.last_name;
       update = true;
     }
     if(useraccount.orgUnitPath!=orgUnitPath)  {


### PR DESCRIPTION
Koden satte förnamnet i google till efternamnet i scoutnet, med följden  att om efternamnet ändrats i scoutnet så blev det fel i Google