### PR TITLE
Non-existings users are now skipped instead of crashing user import

### DIFF
--- a/Anvandare.gs
+++ b/Anvandare.gs
@@ -70,6 +70,14 @@ function Anvandare() {
         else { //För distrikt
           var obj = membersInAList[i];
         }
+
+        if (obj == null) {
+          Logger.log("Användaren  " + membersInAList[i].first_name + " " + membersInAList[i].last_name + " finns inte i Scoutnet eller så saknas det behörighet för att se användare. Kontrollera medlemslistan.");
+          Logger.log("Hoppar över användaren.")
+          // membersInAList-loop
+          continue
+        }
+
         var GoUser = useraccounts.find(u => u.externalIds !== undefined && u.externalIds.some(extid => extid.type === "organization" && extid.value === obj.member_no)); // leta upp befintligt Googlekonto som representerar rätt objekt
         if(GoUser) {
         // Användaren fanns i listan


### PR DESCRIPTION
Lagt till en check på att man verkligen fick en användare tillbaka. 

Stötte på ett case där vi fick `null` tillbaka. Efter lite kontroll verkar det som att användaren ifråga har tillhört kåren för länge sedan och nu dykt upp som aktiv ledare i en annan kår men att det finns något skräp kvar i systemet som gör att användaren dyker upp i våra listor men att vi inte kan hämta information för användare. 

Möjligen borde det kanske vara en Logger.warn eller så, men den funktionaliteten är inte implementerad. 