### PR TITLE
Hämta grupp-ID istället för att färga cellen röd

### DIFF
--- a/Grupper.gs
+++ b/Grupper.gs
@@ -115,9 +115,8 @@ function Grupper(start, slut) {
           
         }
         else { //Om gruppens e-postadress redan finns
-          
-          var cell=selection.getCell(rad_nummer, grd["e-post"]+1);
-          cell.setBackground("red");
+          var group = getAdminDirectoryGroup(email);
+          groupId = group.id;
         }        
       }           
     }


### PR DESCRIPTION
Som det är nu färgas cellen i kalkylarket röd ifall man hittar en grupp som redan finns. Jag vet inte om det fanns någon baktanke med det men konsekvensen för mig blir att man senare försöker anropa AdminDirectory.Members.list med tomt grupp-ID så att allt kraschar.
Nu har jag ändrat så att groupId sätts och anropet till AdminDirectory.Members.list går bra.