### PR TITLE
Use HTTP header auth for Scoutnet requests

### DIFF
--- a/Gemensamma_funktioner.gs
+++ b/Gemensamma_funktioner.gs
@@ -210,8 +210,15 @@ function fetchScoutnetMembersOneMailinglist(scoutnet_list_id, cell_scoutnet_list
   
   Logger.log("Scoutnet mailinglist-id=" + scoutnet_list_id);
   var email_fields = '&contact_fields=email_mum,email_dad,alt_email,mobile_phone';
-  var url = 'https://' + scoutnet_url + '/api/' + organisationType + '/customlists?id=' + groupId + '&key='+ api_key_mailinglists + '&list_id=' + scoutnet_list_id + email_fields;
-  var response = UrlFetchApp.fetch(url, {'muteHttpExceptions': true});
+  var url = 'https://' + scoutnet_url + '/api/' + organisationType + '/customlists?list_id=' + scoutnet_list_id + email_fields;
+  var authHeader = 'Basic ' + Utilities.base64Encode(groupId + ':' + api_key_mailinglists);
+  var response = UrlFetchApp.fetch(
+    url, 
+    {
+      'muteHttpExceptions': true,
+      'headers': { 'Authorization': authHeader}
+    }
+  );
   //Logger.log(response); 
   
   var json = response.getContentText();  
@@ -472,8 +479,15 @@ function getEmailListSyncOption(member, synk_option, boolGoogleAccounts) {
  */
 function fetchScoutnetMembers() {  
   
-  var url = 'https://' + scoutnet_url + '/api/' + organisationType + '/memberlist?id=' + groupId + '&key=' + api_key_list_all + '&pretty=1';
-  var response = UrlFetchApp.fetch(url, {'muteHttpExceptions': true});
+  var url = 'https://' + scoutnet_url + '/api/' + organisationType + '/memberlist?pretty=1';
+  var authHeader = 'Basic ' + Utilities.base64Encode(groupId + ':' + api_key_mailinglists);
+  var response = UrlFetchApp.fetch(
+    url, 
+    {
+      'muteHttpExceptions': true,
+      'headers': { 'Authorization': authHeader}
+    }
+  );
   //Logger.log(response); 
   
   var json = response.getContentText();


### PR DESCRIPTION
Jag fick ett felmeddelande på mailen med vårt API-token i :)  Eftersom scriptet använder autentisering via URL-parametrar läcker autentiseringsuppgifterna om något blir fel i ett API-anrop (i det här fallet verkade det vara något nätverksfel, helt orelaterat till både scriptet och Scoutnet). 

Scoutnet har stöd för ett par sätt att autentisera m.h.a. HTTP-headers, och rekommenderar att använda endera:

* Basic auth (rekommenderat i nuläget, och framåt om man bara vill komma åt resurser för en enhet)
* Bearer token (rekommenderas någon gång i framtiden, särskilt för applikationer som vill hantera data åt flera enheter och få delegerad tillgång med t.ex. oauth). 


Denna PR implementerar basic auth, vilket bör minska risken för läckta nycklar.