### PR TITLE
Fixat spärr för max antal tvingade uppdateringar

### DIFF
--- a/Kontakter/Kontakter.gs
+++ b/Kontakter/Kontakter.gs
@@ -1423,6 +1423,7 @@ function checkDifferenceMemberInfo_(existingData, memberData, nameOfPersonField)
  * @returns {Object} - Ett objekt av typen Person med kontaktinfo för en person
  */
 function makeContactResource_(memberData, customEmailField) {
+  //memberData.first_name = "Test";
   
   //const avatar_updated = "avatar_updated";
   //const avatar_url = "avatar_url";


### PR DESCRIPTION
Spärr för användare för max antal tvingade uppdateringar av kontakter. Nollställs i samband med att kåren kör funktion för att synkronisera vilka användare som ska ges behörighet.