### PR TITLE
Fix utv

### DIFF
--- a/Anvandare.gs
+++ b/Anvandare.gs
@@ -1,6 +1,7 @@
 /**
  * @author Emil Öhman <emil.ohman@scouterna.se>
  * @website https://github.com/Scouterna
+ * @version 2022-12-30
  */
 
 

--- a/Bibliotek/Anvandare-lib.gs
+++ b/Bibliotek/Anvandare-lib.gs
@@ -17,7 +17,7 @@ function synkroniseraAnvandare(INPUT_KONFIG_OBJECT, defaultOrgUnitPath, suspende
 
   let allMembers;
   if ("group" === KONFIG.ORGANISATION_TYPE) {
-    allMembers = fetchScoutnetMembers_(true); //Hämta lista över alla medlemmar
+    allMembers = fetchScoutnetMembers_(true, false); //Hämta lista över alla medlemmar
     console.info("Antal medlemmar i kåren " + allMembers.length);
   }
   

--- a/Bibliotek/Anvandare-lib.gs
+++ b/Bibliotek/Anvandare-lib.gs
@@ -619,7 +619,7 @@ function suspendAccount_(userAccount, suspendedOrgUnitPath) {
  */
 function getGoogleAccounts_(defaultOrgUnitPath) {
 
-  let users;
+  let listOfUsers = [];
 
   for (let n = 0; n < 6; n++) {
     if (0 !== n) {
@@ -635,12 +635,13 @@ function getGoogleAccounts_(defaultOrgUnitPath) {
           maxResults: 150,
           pageToken: pageToken
         });
-        users = page.users;
+        const users = page.users;
         if (users) {
-          //for (let i = 0; i < users.length; i++) {
-            //const user = users[i];
+          for (let i = 0; i < users.length; i++) {
+            const user = users[i];
+            listOfUsers.push(user);
             //console.log('%s (%s)', user.name.fullName, user.primaryEmail);
-          //}
+          }
         } else {
           console.warn('Ingen användare hittades i denna underoganisation.');
           const empty = [];
@@ -649,7 +650,7 @@ function getGoogleAccounts_(defaultOrgUnitPath) {
         pageToken = page.nextPageToken;
       } while (pageToken);
 
-      return users;
+      return listOfUsers;
     
     } catch(e) {
       console.error("Problem med att anropa GoogleTjänst Users.list i funktionen getGoogleAccounts");

--- a/Bibliotek/Gemensamma_funktioner-lib.gs
+++ b/Bibliotek/Gemensamma_funktioner-lib.gs
@@ -1151,7 +1151,7 @@ function intPhoneNumber_(phnum) {
  * @returns {boolean} - Sant eller falskt om korrekt format
  */
 function validatePhonenumberForE164_(phnum) {
-  const regex = /^\+[1-9]\d{1,14}$/;
+  const regex = /^\+[1-9]\d{5,14}$/;
   return regex.test(phnum);
 }
 

--- a/Bibliotek/Gemensamma_funktioner-lib.gs
+++ b/Bibliotek/Gemensamma_funktioner-lib.gs
@@ -647,20 +647,26 @@ function getEmailListSyncOption_(member, synk_option, boolGoogleAccounts) {
  *
  * @returns {Object[]} allMembers - Lista med medlemsobjekt för alla medlemmar i kåren
  */
-function fetchScoutnetMembers_(forceUpdate) {
+function fetchScoutnetMembers_(forceUpdate, fetchWaitingMembers) {
 
   const cacheExpirationInSeconds = 21600; //6 timmar
-  console.time("Hämta kårens alla medlemmar");
+  console.time("Hämta kårens alla medlemmar fetchWaitingMembers-" + fetchWaitingMembers);
   
   const cache = CacheService.getScriptCache();
   
   let kaka;
   let json;
+  let extraUrlParam = "";
 
+  if (fetchWaitingMembers)  {
+    extraUrlParam = "?waiting=1";
+  }
+
+  const nameOfCache = "fetchScoutnetMembers-fetchWaitingMembers-" + fetchWaitingMembers;
   //kaka sätts här för att spara ca 70ms då anropet inte behövs vid forceUpdate
-  if (forceUpdate || !(kaka = cache.get("fetchScoutnetMembers"))) {
+  if (forceUpdate || !(kaka = cache.get(nameOfCache))) {
 
-    const url = 'https://' + KONFIG.SCOUTNET_URL + '/api/' + KONFIG.ORGANISATION_TYPE + '/memberlist';
+    const url = 'https://' + KONFIG.SCOUTNET_URL + '/api/' + KONFIG.ORGANISATION_TYPE + '/memberlist' + extraUrlParam;
     json = urlFetch_(url, KONFIG.API_KEY_LIST_ALL);
     //console.log("Json.length " + json.length);
 
@@ -669,7 +675,7 @@ function fetchScoutnetMembers_(forceUpdate) {
     //100KB ~ 102400 tecken från variabeln json
     //Motsvarar ca 78 medlemmar
     if (json.length < 100000) {
-      cache.put("fetchScoutnetMembers", json, cacheExpirationInSeconds);
+      cache.put(nameOfCache, json, cacheExpirationInSeconds);
       //console.log("Skapa kaka med livslängd " + cacheExpirationInSeconds + " sekunder");
     }
     else {
@@ -677,7 +683,7 @@ function fetchScoutnetMembers_(forceUpdate) {
     }
   }
   else {
-    console.log("Kakan för att hämta alla medlemmar fanns redan");
+    console.log("Kakan för att hämta alla medlemmar fanns redan fetchWaitingMembers-" + fetchWaitingMembers);
     json = kaka;
   }
   
@@ -704,7 +710,8 @@ function fetchScoutnetMembers_(forceUpdate) {
     //console.log(member);
     allMembers.push(member);
   }
-  console.timeEnd("Hämta kårens alla medlemmar");
+  console.log("Antal medlemmar " + allMembers.length + " fetchWaitingMembers-" + fetchWaitingMembers)
+  console.timeEnd("Hämta kårens alla medlemmar fetchWaitingMembers-" + fetchWaitingMembers);
   return allMembers;
 }
 

--- a/Bibliotek/Gemensamma_funktioner-lib.gs
+++ b/Bibliotek/Gemensamma_funktioner-lib.gs
@@ -1115,6 +1115,10 @@ function removeDublicates_(list) {
  */
 function intPhoneNumber_(phnum) {
 
+  if ("" === phnum) {
+    return "";
+  }
+
   const numPatternOnlyDigits = /[^0-9]+/g;
   phnum = phnum.replace(numPatternOnlyDigits, '');
   //Ta bort alla ickesiffror, mellanslag

--- a/Bibliotek/Gemensamma_funktioner-lib.gs
+++ b/Bibliotek/Gemensamma_funktioner-lib.gs
@@ -644,6 +644,7 @@ function getEmailListSyncOption_(member, synk_option, boolGoogleAccounts) {
  * Hämta lista över alla medlemmar
  * 
  * @param {boolean} forceUpdate - Tvinga uppdatering av data eller ej från Scoutnet
+ * @param {boolean} fetchWaitingMembers - Om "medlemmar" från väntelistan ska hämtas i stället för riktiga medlemmar
  *
  * @returns {Object[]} allMembers - Lista med medlemsobjekt för alla medlemmar i kåren
  */

--- a/Bibliotek/Gemensamma_funktioner-lib.gs
+++ b/Bibliotek/Gemensamma_funktioner-lib.gs
@@ -1087,7 +1087,7 @@ function deleteRowsFromSpreadsheet_(sheet, delete_rows) {
 function removeDublicates_(list) {
   const listWithoutDuplicates = []
   
-  for (let i = 0; i < list.length; i++){
+  for (let i = 0; i < list.length; i++) {
     if (!listWithoutDuplicates.includes(list[i])){
       listWithoutDuplicates.push(list[i])
     }
@@ -1108,40 +1108,31 @@ function removeDublicates_(list) {
  */
 function intPhoneNumber_(phnum) {
 
-  let regex = /^\+/;
-  //console.log('Telefonnummer före: %s', phnum);
-  const res = phnum.match(regex);
-  if (res) {
-    let countryCodeIsFound = false;
- 
-    const countryCodes = [];
-    countryCodes.push("43"); //
-    countryCodes.push("44"); //
-    countryCodes.push("45"); //Danmark
-    countryCodes.push("46"); //Sverige
-    for (let k in countryCodes) {
-      regex = new RegExp('^\\+' + countryCodes[k], 'g');
-      if (phnum.match(regex)) {
-        phnum = "+" + countryCodes[k] + phnum.substr(3).replace(/[^0-9]/g, '');
-        countryCodeIsFound = true;
-      }
-    }
-    if (!countryCodeIsFound) {
-      phnum = null;
-    }
-    //console.log('Efter landskod %s', phnum);
-  }
-  else {
-    //console.log('Telefonnummer börjar ej med landskod');
-    if (phnum.replace(/[^0-9]/g, '').match(/^0/)) {
-      phnum = "+46" + phnum.replace(/[^0-9]/g, '').substr(1);
-    }
-    else {
-      //phnum = null
+  const numPatternOnlyDigits = /[^0-9]+/g;
+  phnum = phnum.replace(numPatternOnlyDigits, '');
+  //Ta bort alla ickesiffror, mellanslag
+  
+  const numPatternNoLeadingZeros = /[0]*/;
+  phnum = phnum.replace(numPatternNoLeadingZeros, '');
+  //Ta bort inledande nollor
+
+  const countryCodes = [];
+  countryCodes.push("44"); //Storbritannien
+  countryCodes.push("45"); //Danmark
+  countryCodes.push("46"); //Sverige
+  countryCodes.push("47"); //Norge
+  countryCodes.push("358"); //Finland
+
+  for (let i = 0; i < countryCodes.length; i++) {
+
+    if (phnum.startsWith(countryCodes[i]))  {
+      //console.log("Telefonnumret tillhör land " + countryCodes[i]);
+      return "+" + phnum;
     }
   }
-  //console.log('Klarformaterat telefonnummer %s', phnum);
-  return phnum
+
+  //Lägg till landskod om ingen finns innan
+  return "+46" + phnum;
 }
 
 

--- a/Bibliotek/Kontakter-Admin-lib.gs
+++ b/Bibliotek/Kontakter-Admin-lib.gs
@@ -506,7 +506,9 @@ function getContactGroupsData_(listOfGroupEmails, forceUpdate) {
   let contactGroupsList = [];
 
   //Hämta lista med alla medlemmar i kåren och alla deras attribut
-  let allMembers = fetchScoutnetMembers_(forceUpdate);
+  const allActiveMembers = fetchScoutnetMembers_(true, false);
+  const allWaitingMembers = fetchScoutnetMembers_(true, true);
+  let allMembers = [...allActiveMembers, ...allWaitingMembers];
   let filteredMembers = filterMemberAttributes_(allMembers);  
 
   //Listor med telefonnummer, e-postadress och medlemsnummer för alla vuxna medlemmar för att

--- a/Bibliotek/Kontakter-Admin-lib.gs
+++ b/Bibliotek/Kontakter-Admin-lib.gs
@@ -140,9 +140,11 @@ function updateContactGroupsAuthnSheetUsers(INPUT_KONFIG_OBJECT) {
     sheet.insertRows(slut, delete_rows.length);
   }
 
-  //Radera det som står i kolumnen för antal tvingade uppdateringar
-  const range_tvingade_uppdateringar = sheet.getRange(start, grd["tvingade_uppdateringar"]+1, slut-start+1);
-  range_tvingade_uppdateringar.clear();
+  if (0 !== slut-start+1)  {  //Om det redan står några personer i listan
+    //Radera det som står i kolumnen för antal tvingade uppdateringar
+    const range_tvingade_uppdateringar = sheet.getRange(start, grd["tvingade_uppdateringar"]+1, slut-start+1);
+    range_tvingade_uppdateringar.clear();
+  }
 
   console.info("Lägga till eventuella nedanstående e-postadresser så att de får behörighet");
   for (let i = 0; i < listOfEmailsShouldHaveAccess.length; i++) {
@@ -155,18 +157,20 @@ function updateContactGroupsAuthnSheetUsers(INPUT_KONFIG_OBJECT) {
     }
   }
 
-  const range_kontakter_anvandare = sheet.getRange(start, grd["e-post"]+1, slut-start+1, 5);
-  
-  //Vi tar bort alla skyddade områden
-  const protections = sheet.getProtections(SpreadsheetApp.ProtectionType.RANGE);
-  for (let i = 0; i < protections.length; i++) {
-    const protection = protections[i];
-    if (protection.canEdit()) {
-      protection.remove();
+  if (0 !== slut-start+1)  {  //Om det redan står några personer i listan
+    const range_kontakter_anvandare = sheet.getRange(start, grd["e-post"]+1, slut-start+1, 5);
+    
+    //Vi tar bort alla skyddade områden
+    const protections = sheet.getProtections(SpreadsheetApp.ProtectionType.RANGE);
+    for (let i = 0; i < protections.length; i++) {
+      const protection = protections[i];
+      if (protection.canEdit()) {
+        protection.remove();
+      }
     }
+    //Vi skyddar kalkylarket för Kontakter-Användare så man inte råkar ändra av misstag
+    range_kontakter_anvandare.protect().setWarningOnly(true);
   }
-  //Vi skyddar kalkylarket för Kontakter-Användare så man inte råkar ändra av misstag
-  range_kontakter_anvandare.protect().setWarningOnly(true); 
 }
 
 

--- a/Bibliotek/Medlemslistor-lib.gs
+++ b/Bibliotek/Medlemslistor-lib.gs
@@ -603,13 +603,19 @@ function getAndMakeAttachments_(attachmentsInput, documentToMerge, attribut, dat
       const copy_file = DocumentApp.openById(copy_id);
 
       const body = copy_file.getBody();
-      replaceContentOfDocument_(body, attribut, dataArray);
+      if (body) {
+        replaceContentOfDocument_(body, attribut, dataArray);
+      }
 
       const header = copy_file.getHeader();
-      replaceContentOfDocument_(header, attribut, dataArray);
+      if (header) {
+        replaceContentOfDocument_(header, attribut, dataArray);
+      }
 
       const footer = copy_file.getFooter();
-      replaceContentOfDocument_(footer, attribut, dataArray);
+      if (footer) {
+        replaceContentOfDocument_(footer, attribut, dataArray);
+      }
 
       console.log("URL för temporärt skapad fil är");
       console.log(copy_file.getUrl());

--- a/Bibliotek/Medlemslistor-lib.gs
+++ b/Bibliotek/Medlemslistor-lib.gs
@@ -61,8 +61,10 @@ function synkroniseraMedlemslistor(INPUT_KONFIG_OBJECT, start, slut, shouldUpdat
   const sheetDataMedlemslistor = getDataFromActiveSheet_("Medlemslistor");
   const grd = getMedlemslistorKonfigRubrikData_();
   //Hämta lista med alla medlemmar i kåren och alla deras attribut
-  const allMembers = fetchScoutnetMembers_(true);
-  console.info("Antal medlemmar i kåren " + allMembers.length);
+  const allActiveMembers = fetchScoutnetMembers_(true, false);
+  const allWaitingMembers = fetchScoutnetMembers_(true, true);
+  const allMembers = [...allActiveMembers, ...allWaitingMembers];
+  console.info("Antal medlemmar i kåren samt väntelistan " + allMembers.length);
 
   const sheet = sheetDataMedlemslistor["sheet"];
   const selection = sheetDataMedlemslistor["selection"];

--- a/Gemensamma_funktioner.gs
+++ b/Gemensamma_funktioner.gs
@@ -1,6 +1,7 @@
 /**
  * @author Emil Öhman <emil.ohman@scouterna.se>
  * @website https://github.com/Scouterna
+ * @version 2022-12-30
  */
 
 

--- a/Grupper.gs
+++ b/Grupper.gs
@@ -1,6 +1,7 @@
 /**
  * @author Emil Öhman <emil.ohman@scouterna.se>
  * @website https://github.com/Scouterna
+ * @version 2022-12-30
  */
 
 

--- a/Konfiguration.gs
+++ b/Konfiguration.gs
@@ -1,6 +1,7 @@
 /**
  * @author Emil Öhman <emil.ohman@scouterna.se>
  * @website https://github.com/Scouterna
+ * @version 2022-12-30
  */
 
 

--- a/Kontakter-Admin.gs
+++ b/Kontakter-Admin.gs
@@ -1,6 +1,7 @@
 /**
  * @author Emil Öhman <emil.ohman@scouterna.se>
  * @website https://github.com/Scouterna
+ * @version 2022-12-30
  */
 
 

--- a/Kontakter-Anvandare.gs
+++ b/Kontakter-Anvandare.gs
@@ -1,6 +1,7 @@
 /**
  * @author Emil Öhman <emil.ohman@scouterna.se>
  * @website https://github.com/Scouterna
+ * @version 2022-12-30
  */
 
 

--- a/Medlemslistor.gs
+++ b/Medlemslistor.gs
@@ -1,6 +1,7 @@
 /**
  * @author Emil Öhman <emil.ohman@scouterna.se>
  * @website https://github.com/Scouterna
+ * @version 2022-12-30
  */
 
 

--- a/Start_funktioner.gs
+++ b/Start_funktioner.gs
@@ -1,6 +1,7 @@
 /**
  * @author Emil Öhman <emil.ohman@scouterna.se>
  * @website https://github.com/Scouterna
+ * @version 2022-12-30
  */
 
 


### PR DESCRIPTION
* Fixat problem vid Medlemslistor när sidhuvud och sidfot är tom och inget har stått där tidigare
* Fungerar nu med synkronisering av användare med återställningstelefonnummer som börjar med 0046
* Går nu att använda personer från kårens väntelista i Medlemslistor & Kontakter
* Fixat bugg vid fler än 150 användarkonton
* Fixat bugg som gjorde att det inte gick att uppdatera listan över vilka i kåren som ska få synkronisera kontakter om listan är tom.
* Lagt till datum för när filer som ej används i biblioteket senast är ändrade